### PR TITLE
Set reduceIdents to false to fix keyframes issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Example:
 
 | Name | Type | Description |
 |------|-------------|-------|
-| camelize | boolean | Wether to export camelized versions of the keys |
+| camelize | boolean | Whether to export camelized versions of the keys |
+| reduceIdents | boolean | Whether to minify @ rules names |
 | scopedNameFormat | string | Format for class name. It leverages [this](https://github.com/webpack/loader-utils#interpolatename). |
 | mode | enum | 'pure', 'global', or 'local' |

--- a/packages/a-css-loader/index.js
+++ b/packages/a-css-loader/index.js
@@ -25,7 +25,8 @@ const DEFAULT_OPTIONS = Object.freeze({
 function postcssPlugins(symbolsCollector, loaderContext, {
   mode,
   scopedNameFormat,
-  minimize
+  minimize,
+  reduceIdents
 }) {
   const localsAgent = symbolsCollector.createImportedItemCollectorAgent(['locals']);
   const urlsAgent = symbolsCollector.createImportedItemCollectorAgent([/* no namespace for url requires */]);
@@ -40,7 +41,12 @@ function postcssPlugins(symbolsCollector, loaderContext, {
   ];
 
   if (minimize) {
-    const options = typeof minimize === 'object' ? minimize : { reduceIdents: false };
+    const options = typeof minimize === 'object' ? minimize : {};
+
+    if (typeof reduceIdents === 'boolean') {
+      options.reduceIdents = reduceIdents;
+    }
+
     plugins.push(cssnano(options));
   }
 

--- a/packages/a-css-loader/index.js
+++ b/packages/a-css-loader/index.js
@@ -40,7 +40,7 @@ function postcssPlugins(symbolsCollector, loaderContext, {
   ];
 
   if (minimize) {
-    const options = typeof minimize === 'object' ? minimize : {};
+    const options = typeof minimize === 'object' ? minimize : { reduceIdents: false };
     plugins.push(cssnano(options));
   }
 

--- a/packages/a-css-loader/package.json
+++ b/packages/a-css-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a-css-loader",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.12",
   "description": "",
   "main": "index.js",
   "config": {


### PR DESCRIPTION
Set the `reduceIdents` options to `false` on cssnano to fix an issue with `@keyframes` animations overwriting each other.